### PR TITLE
Adding Kokoro build and config files

### DIFF
--- a/.kokoro/build-and-test.sh
+++ b/.kokoro/build-and-test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+set -x
+
+readonly ROOT=$(dirname "${BASH_SOURCE}")/..
+
+
+mkdir -p ${ROOT}/bin
+go build -o ${ROOT}/bin/gce-csi-driver ${ROOT}/cmd/
+go test -timeout 30s ${ROOT}/pkg/test -run ^TestSanity$

--- a/.kokoro/presubmit.cfg
+++ b/.kokoro/presubmit.cfg
@@ -1,0 +1,3 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+build_file: "compute-persistent-disk-csi-driver/.kokoro/build-and-test.sh"


### PR DESCRIPTION
Adding configuration and build files required for Kokoro Presubmit tests to be run on PRs. Not necessarily correct.